### PR TITLE
Fix off by one error when parsing arguments

### DIFF
--- a/runtime.c
+++ b/runtime.c
@@ -65,7 +65,7 @@ int main(int argc, char **argv) {
   int64_t *argdata = malloc(sizeof(int64_t) * argnum);
   if (argnum && !argdata) fail("main", "Could not allocate memory for arguments");
   for (int i = 1; i < argc; i++) {
-    argdata[i] = strtol(argv[i], 0, 10);
+    argdata[i - 1] = strtol(argv[i], 0, 10);
     if (errno) fail("main", "Command line argument too large");
   }
   struct actual_args args = { argnum, argdata, 0, 0, 0 };


### PR DESCRIPTION
The runtime has a buffer overflow bug when parsing command line arguments before calling `jpl_main`. This results in an invalid write whenever any arguments are passed.

Valgrind will detect this error when running any JPL program with at least one argument:
```
tests valgrind ./a.out 1
==980031== Memcheck, a memory error detector
==980031== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==980031== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==980031== Command: ./a.out 1
==980031==
==980031== Invalid write of size 8
==980031==    at 0x10A68A: main (in /home/timb44/school/compilers/tests/a.out)
==980031==  Address 0x4b7f048 is 0 bytes after a block of size 8 alloc'd
==980031==    at 0x4846828: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==980031==    by 0x10A64E: main (in /home/timb44/school/compilers/tests/a.out)
==980031==
==980031==
==980031== HEAP SUMMARY:
==980031==     in use at exit: 8 bytes in 1 blocks
==980031==   total heap usage: 1 allocs, 0 frees, 8 bytes allocated
==980031==
==980031== LEAK SUMMARY:
==980031==    definitely lost: 8 bytes in 1 blocks
==980031==    indirectly lost: 0 bytes in 0 blocks
==980031==      possibly lost: 0 bytes in 0 blocks
==980031==    still reachable: 0 bytes in 0 blocks
==980031==         suppressed: 0 bytes in 0 blocks
==980031== Rerun with --leak-check=full to see details of leaked memory
==980031==
==980031== For lists of detected and suppressed errors, rerun with: -s
==980031== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

This should fix issue #3 in the class repository.